### PR TITLE
Update to 0.11.0noarch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   url: https://github.com/matplotlib/cycler/archive/v{{ version }}.tar.gz
   fn: cycler-v{{ version }}.tar.gz
-  sha256: 9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f
+  sha256: 2530b40270be9e5e8c5f570d15a934c5dc9737ce3f3ba54307b371655e48e7e4
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   skip: True  # [py<36]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -28,6 +29,7 @@ test:
     - cycler
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,34 +1,42 @@
+{% set version = "0.11.0" %}
+
 package:
   name: cycler
-  version: 0.10.0
+  version: {{ version }}
 
 source:
-  url: https://github.com/matplotlib/cycler/archive/v0.10.0.tar.gz
-  fn: cycler-v0.10.0.tar.gz
-  sha256: b6d217635e03024196225367b1a438996dbbf0271bec488f00584f0e7dc15cfa
+  url: https://github.com/matplotlib/cycler/archive/v{{ version }}.tar.gz
+  fn: cycler-v{{ version }}.tar.gz
+  sha256: 9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f
 
 build:
   number: 0
+  skip: True  # [py<36]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   host:
     - python
+    - pip
     - setuptools
-    - six
+    - wheel
   run:
-    - python
-    - six
+    - python >=3.6
 
 test:
   imports:
     - cycler
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: http://matplotlib.org/cycler
-  license: BSD 3-Clause
+  license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
-  summary: 'Composable style cycles.'
+  summary: Composable style cycles.
   description: |
     Cycler is a package used to create composable style cycles.
   doc_url: http://matplotlib.org/cycler/


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/matplotlib/cycler/issues
Github releases:  https://github.com/matplotlib/cycler/releases
Upstream license:  License file:  https://github.com/matplotlib/cycler/blob/master/LICENSE
Upstream setup.py:  https://github.com/matplotlib/cycler/blob/main/setup.py

The package cycler is mentioned inside the packages:
matplotlib |

Actions:
1. Update dependencies
2. Add license_family
3. Add pip check
4. Fix sha256
5. Use `noarch: python`
6. Update `script`

Result:
- all-succeeded