### PR TITLE
Use noarch python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,12 +7,13 @@ package:
 source:
   url: https://github.com/matplotlib/cycler/archive/v{{ version }}.tar.gz
   fn: cycler-v{{ version }}.tar.gz
-  sha256: 9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f
+  sha256: 2530b40270be9e5e8c5f570d15a934c5dc9737ce3f3ba54307b371655e48e7e4
 
 build:
   number: 0
   skip: True  # [py<36]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -28,6 +29,7 @@ test:
     - cycler
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/matplotlib/cycler/issues
Github releases:  https://github.com/matplotlib/cycler/releases
Upstream license:  License file:  https://github.com/matplotlib/cycler/blob/master/LICENSE
Upstream setup.py:  https://github.com/matplotlib/cycler/blob/main/setup.py

The package cycler is mentioned inside the packages:
matplotlib |

Actions:
1. Update dependencies
2. Add license_family
3. Add pip check
4. Fix sha256
5. Use `noarch: python`
6. Update `script`

Result:
- all-succeeded